### PR TITLE
Remove the logging configuration

### DIFF
--- a/requests_oauthlib/__init__.py
+++ b/requests_oauthlib/__init__.py
@@ -1,5 +1,3 @@
-import logging
-
 from .oauth1_auth import OAuth1
 from .oauth1_session import OAuth1Session
 from .oauth2_auth import OAuth2
@@ -13,4 +11,3 @@ if requests.__version__ < '2.0.0':
            'requests-oauthlib expects, please upgrade to 2.0.0 or later.')
     raise Warning(msg % requests.__version__)
 
-logging.getLogger('requests_oauthlib').addHandler(logging.NullHandler())


### PR DESCRIPTION
We manage the logging settings centrally and this line conflicts with our internal configuration.